### PR TITLE
Bugfix/utilpack use defaults

### DIFF
--- a/components/utilpack/_base.scss
+++ b/components/utilpack/_base.scss
@@ -1,7 +1,7 @@
 // Fylgja (https://fylgja.dev)
 // Licensed under MIT Open Source
 
-// Helper to set form common defaults needed for utilpack
+// Helper to set common defaults needed for utilpack
 
 [class*="border-"],
 [class*="divider-"] {

--- a/components/utilpack/_helper.scss
+++ b/components/utilpack/_helper.scss
@@ -5,15 +5,6 @@
 @use "sass:meta";
 @use "@fylgja/mq" as *;
 
-@use "defaults/border" as *;
-@use "defaults/box-alignment" as *;
-@use "defaults/color" as *;
-@use "defaults/flex" as *;
-@use "defaults/layout" as *;
-@use "defaults/sizing" as *;
-@use "defaults/spacers" as *;
-@use "defaults/typography" as *;
-
 // * The separator style can be a safe css separator, the "-" (hyphen)
 // * Or the unsafe css "\\:" (TailwindCSS separator)
 // * Or use a underscore "_".
@@ -23,29 +14,3 @@ $utilpack-breakpoints: $mq-breakpoints !default;
 
 $utilpack: () !default;
 $utilpack-defaults: () !default;
-
-// prettier-ignore
-@if $utilpack-defaults {
-    @each $map in (
-        $utilpack-defaults-border,
-        $utilpack-defaults-box-alignment,
-        $utilpack-defaults-color,
-        $utilpack-defaults-flex,
-        $utilpack-defaults-layout,
-        $utilpack-defaults-sizing,
-        $utilpack-defaults-spacers,
-        $utilpack-defaults-typography,
-    ) {
-        $utilpack-defaults: if(
-            meta.type-of($map) == map,
-            map.merge($map, $utilpack-defaults),
-            $utilpack-defaults
-        );
-    }
-}
-
-$utilpack: if(
-    meta.type-of($utilpack-defaults) == map,
-    map.merge($utilpack-defaults, $utilpack),
-    $utilpack
-);

--- a/components/utilpack/_index.scss
+++ b/components/utilpack/_index.scss
@@ -7,6 +7,9 @@
 @use "api" as utilpack;
 @use "helper" as *;
 @use "base";
+@use "defaults" as *;
+
+$utilpack: map.merge($utilpack-defaults, $utilpack) !default;
 
 // Build each util class
 @each $key, $util in $utilpack {

--- a/components/utilpack/defaults/_index.scss
+++ b/components/utilpack/defaults/_index.scss
@@ -1,0 +1,26 @@
+@use "sass:map";
+@use "sass:meta";
+@use "../helper" as *;
+@use "border" as *;
+@use "box-alignment" as *;
+@use "color" as *;
+@use "flex" as *;
+@use "layout" as *;
+@use "sizing" as *;
+@use "spacers" as *;
+@use "typography" as *;
+
+$utilpack-defaults: map.merge($utilpack-defaults-border, $utilpack-defaults);
+$utilpack-defaults: map.merge(
+    $utilpack-defaults-box-alignment,
+    $utilpack-defaults
+);
+$utilpack-defaults: map.merge($utilpack-defaults-color, $utilpack-defaults);
+$utilpack-defaults: map.merge($utilpack-defaults-flex, $utilpack-defaults);
+$utilpack-defaults: map.merge($utilpack-defaults-layout, $utilpack-defaults);
+$utilpack-defaults: map.merge($utilpack-defaults-sizing, $utilpack-defaults);
+$utilpack-defaults: map.merge($utilpack-defaults-spacers, $utilpack-defaults);
+$utilpack-defaults: map.merge(
+    $utilpack-defaults-typography,
+    $utilpack-defaults
+);


### PR DESCRIPTION
Fixes #40 

With this fix you can now any of the defaults outside the utilpack import.

Sample code from fix test:

```scss
@use "sass:map";
@use "@fylgja/utilpack/defaults/spacers" as *;
@use "@fylgja/utilpack/helper" with (
    $utilpack: map.merge(
        (
            "margin-right": (
                "class": "mr",
                "values": $utilpack-margin-all,
                "responsive": $enable-utilpack-margin-responsive,
                "print": $enable-utilpack-margin-print,
                "important": $enable-utilpack-margin-important,
            ),
        ),
        $utilpack-defaults-spacers
    ),
);
@use "@fylgja/utilpack/index";
```